### PR TITLE
Fixes crash from PeaceMod removing the auto place of biters

### DIFF
--- a/prototypes/prototype_utils.lua
+++ b/prototypes/prototype_utils.lua
@@ -5,7 +5,9 @@ function is_partial()
 end
 
 function add_peak(ent, peak)
-  ent.autoplace.peaks[#ent.autoplace.peaks+1] = peak
+  if (ent.autoplace ~= null) then
+    ent.autoplace.peaks[#ent.autoplace.peaks+1] = peak
+  end
 end
 
 function change_ocataves(autoplace, octaves)

--- a/prototypes/prototype_utils.lua
+++ b/prototypes/prototype_utils.lua
@@ -5,7 +5,7 @@ function is_partial()
 end
 
 function add_peak(ent, peak)
-  if (ent.autoplace ~= null) then
+  if (ent.autoplace ~= nil) then
     ent.autoplace.peaks[#ent.autoplace.peaks+1] = peak
   end
 end


### PR DESCRIPTION
Since PeaceMod removes the autoplace entry for biters then RSO will crash. This checks if the autoplace is there before modifying the peak.
